### PR TITLE
Fix a use-after-free in ApfsDriverLoader

### DIFF
--- a/Platform/ApfsDriverLoader/ApfsDriverLoader.c
+++ b/Platform/ApfsDriverLoader/ApfsDriverLoader.c
@@ -1029,8 +1029,6 @@ ApfsDriverLoaderStart (
                       );
   }
 
-  FreePool (ApfsBlock);
-
   //
   // Fill public AppleFileSystemEfiBootRecordInfo protocol interface
   //
@@ -1063,6 +1061,8 @@ ApfsDriverLoaderStart (
     if (Private != NULL) {
       FreePool (Private);
     }
+    FreePool (ApfsBlock);
+
     return Status;
   }
 
@@ -1071,6 +1071,8 @@ ApfsDriverLoaderStart (
     EfiFileBuffer,
     EfiBootRecordBlock->EfiFileLen
     );
+
+  FreePool (ApfsBlock);
 
   if (EFI_ERROR (Status)) {
     gBS->UninstallProtocolInterface (

--- a/Platform/ApfsDriverLoader/ApfsDriverLoader.c
+++ b/Platform/ApfsDriverLoader/ApfsDriverLoader.c
@@ -1034,6 +1034,7 @@ ApfsDriverLoaderStart (
   //
   Private = AllocatePool (sizeof (APFS_DRIVER_INFO_PRIVATE_DATA));
   if (Private == NULL) {
+    FreePool (ApfsBlock);
     return EFI_OUT_OF_RESOURCES;
   }
 


### PR DESCRIPTION
EfiBootRecordBlock is pointing to ApfsBlock, so if ApfsBlock is freed before StartApfsDriver() is called things will break on any platform where the allocator poisons freed pages (such as EDK2 development builds)