### PR TITLE
Extend the timeout to five seconds

### DIFF
--- a/Application/VerifyMsrE2/VerifyMsrE2.c
+++ b/Application/VerifyMsrE2/VerifyMsrE2.c
@@ -78,7 +78,7 @@ UefiMain (
 
   Print (L"Starting All APs to verify 0xE2 register...\n", Status);
 
-  Status = mMpServices->StartupAllAPs (mMpServices, ReadMsrE2, TRUE, NULL, 1000000, NULL, NULL);
+  Status = mMpServices->StartupAllAPs (mMpServices, ReadMsrE2, TRUE, NULL, 5e6, NULL, NULL);
   if (EFI_ERROR (Status)) {
     Print (L"Failed to StartupAllAPs - %r\n", Status);
     return Status;


### PR DESCRIPTION
One second is too short to enumerate processors with lots of cores and dual processor systems.